### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,9 @@
 name: Publish package to npm
 
+permissions:
+  contents: write
+  packages: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/style-dictionary/security/code-scanning/1](https://github.com/digitalservicebund/style-dictionary/security/code-scanning/1)

Add an explicit `permissions` block to the workflow. The least privilege approach requires only enabling the permissions necessary for this workflow. For publishing, committing, pushing, and release creation, the following are likely needed:
- `contents: write` (for pushing commits/tags)
- `packages: write` (for publishing to npm)
- `id-token: write` may be required if the npm publish action is using OIDC authentication (not shown in current workflow, but good to include if possible)

You can add the `permissions` block either at the workflow root level (applies to all jobs), or under the specific job definition (`release:`) to restrict permissions just for that job. Best practice is to set restrictive permissions globally (e.g. `contents: read` at the root) and then more permissive where needed, but for this workflow with a single job, setting it at the job or root level with only the necessary permissions suffices.

The change will be made in `.github/workflows/publish.yml`—add the `permissions` block as close to the top as reasonable (before or after `on:`), or under the `release` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
